### PR TITLE
Fix non-import loading of MailSlurp package

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ OR
 ```javascript
 // import the package
 import MailSlurp from "mailslurp-client"
-// const MailSlurp = require("mailslurp-client")
+// const MailSlurp = require("mailslurp-client").default
 
 // create an instance with your apiKey
 const api = new MailSlurp({ apiKey: "test" })


### PR DESCRIPTION
When using the MailSlurp package in a non-babel/non-typescript environment, I get the following error during the constructor process:
`TypeError: MailSlurp is not a constructor`

I've faced this issue in the past, and the answer is to use the `.default` property (alternatively, it looks like `.MailSlurp` would work as well).