### PR TITLE
Fix "test email processing" example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,17 @@ test('my app can send emails', async () => {
     // trigger an app action that sends an email
     await signUpForMyApp(inbox.emailAddress)
 
-    // fetch welcome email from the inbox
+    // fetch emails from the inbox
     const emails = await api.getEmails(inbox.id, { minCount: 1 })
 
-    // assert that the correct email was sent
-    expect(emails[0].length).toBe(1)
-    expect(emails[0].content).toBe(expectedContent)
+    // assert that there is an email in the inbox
+    expect(emails.length).toBe(1)
+    
+    // fetch specific email content
+    const email = await api.getEmail(emails[0].id)
+    
+    // assert that correct email was sent
+    expect(email.body).toBe(expectedContent)
 }
 ```
 


### PR DESCRIPTION
From my usage, the `getEmails` function returns an array of emails, but those emails only contain an ID and created date. To get the actual email content, you need to follow that with a `getEmail` call, passing in the email id, then check the body property.